### PR TITLE
Set up in solidarity bot

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,0 +1,13 @@
+rules:
+  # TODO(josephperrott): After migrating away from master branch
+  # terminology, move check level to failure
+  master:
+    level: notice
+  slave:
+    level: failure
+  whitelist:
+    level: failure
+  blacklist:
+    level: failure
+ignore:
+ - ".github/in-solidarity.yml"


### PR DESCRIPTION
Sets up a organization wide configuration of the in solidarity bot. This
bot will perform checks on changed code to look for usages of non-inclusive
terms, setting a failing status check for usages of whitelist, blacklist
and slave.

Note: A notice, rather than failure, is used for usages of master due to
our current usage of the term master for our primary branches.


In solidarity bot source: https://github.com/jpoehnelt/in-solidarity-bot